### PR TITLE
Calculate precision factor dynamically

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ Opera [old versions](http://www.opera.com/docs/specs/presto28/css/o-vendor/) sup
 
 ## Changelog
 
+### v1.1.0
+
+* \- Use more precise (not fixed) precision factor for the calculation
+
 ### v1.0.1
 
 * \- Remove "ci.testling.com"

--- a/index.js
+++ b/index.js
@@ -4,6 +4,16 @@ function GCD(a, b) {
   return GCD(b, a % b)
 }
 
+function findPrecision(n) {
+  var e = 1
+
+  while (Math.round(n * e) / e !== n) {
+    e *= 10
+  }
+
+  return e
+}
+
 function num2fraction(num) {
   if (num === 0) return 0
 
@@ -12,7 +22,7 @@ function num2fraction(num) {
   }
 
 
-  var precision = 100000000 //精确度
+  var precision = findPrecision(num) //精确度
   var number = num * precision
   var gcd = GCD(number, precision)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "num2fraction",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Convert number to fraction",
   "main": "index.js",
   "author": {

--- a/test/test.js
+++ b/test/test.js
@@ -9,6 +9,7 @@ test('Must be equal', function(t) {
   t.equal(num2fraction(1.5), '3/2')
   t.equal(num2fraction(2), '2/1')
   t.equal(num2fraction(3), '3/1')
+  t.equal(num2fraction(2.555), '511/200')
   t.equal(num2fraction('3em'), '3/1')
   t.equal(num2fraction('1.5px'), '3/2')
   t.end()


### PR DESCRIPTION
Hi,

Seems that on some occasions fixed precision factor is too imprecise and precision needs to be calculated based on input floating point number.

Some of the failing examples:

1.1 = 7381975040000001/6710886400000000
2.555 = 8573157376000001/3355443200000000
2.2 = 7381975040000001/3355443200000000
2.3 = 7717519359999999/3355443200000000

Best regards